### PR TITLE
set showSpotlight to false as default

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -32,7 +32,7 @@ export default class JoyrideOverlay extends React.Component<OverlayProps, State>
   state = {
     isScrolling: false,
     mouseOverSpotlight: false,
-    showSpotlight: true,
+    showSpotlight: false,
   };
 
   componentDidMount() {


### PR DESCRIPTION
Need to add this to prevent highlight blinking when scroll to element

## Card:

https://app.clickup.com/t/20696747/WALL-2676